### PR TITLE
Only print debug message when AS5048A_DEBUG is set

### DIFF
--- a/lib/AS5048A/AS5048A.cpp
+++ b/lib/AS5048A/AS5048A.cpp
@@ -197,7 +197,9 @@ word AS5048A::read(word registerAddress){
 
 	//Check if the error bit is set
 	if (left_byte & 0x40) {
-		Serial.println("Setting Error bit");
+#ifdef AS5048A_DEBUG
+		Serial.println("Setting error bit");
+#endif
 		errorFlag = true;
 	}
 	else {


### PR DESCRIPTION
The "Setting error bit" message is currently printed to serial whether or not AS5048A_DEBUG is set.