### PR TITLE
ESP32 Support, General refactoring for architecture-independant code, Zero position write support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.DS_Store
+
 # Object files
 *.o
 *.ko

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 *.pch
 
 # Libraries
+lib/
 *.lib
 *.a
 *.la

--- a/README.md
+++ b/README.md
@@ -4,5 +4,8 @@ AS5048A-Arduino
 A simple SPI library to interface with Austria Microsystem's AS5048A angle sensor with an Arduino.
 
 The sensor should be connected to the hardware SPI pins (MISO, MOSI, SCK). The CS pin can be connected to any GPIO pin but should be passed to the constructor.
+The second argument in the constructor is the time the library should wait for the sensor to have the data available in order to read it. It is not usually a problem
+using ATmega microcontrollers but it can be a problem using fast microcontrollers such as the ESP32. For these cases, a value of around 50 would do, but should be
+customized.
 
 The angle sensor is described in more detail [here](zoetrope.io/AS5048)

--- a/README.md
+++ b/README.md
@@ -9,3 +9,11 @@ The second (optional) argument in the constructor is the time the library should
 using ATmega microcontrollers in Arduino UNO but it can be a problem using fast microcontrollers such as the ESP32. For these cases, a value of around 50 would do, but should be fine tuned.
 
 The angle sensor is described in more detail [here](zoetrope.io/AS5048)
+
+
+Installation
+================
+The simplest way to install the library into Arduino IDE is by creating a soft link:
+```
+ln -s $REPOSITORY_DIR/lib/AS5048A/ $ARDUINO_DIR/libraries/AS5048A
+```

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 AS5048A-Arduino
 ===============
 
-A simple SPI library to interface with Austria Microsystem's AS5048A angle sensor with an Arduino.
+A simple SPI library to interface with Austria Microsystem's AS5048A angle sensor with Arduino C Framework and Libraries included in Arduino IDE.
+It is tested in Arduino microcontrollers and ESP32.
 
 The sensor should be connected to the hardware SPI pins (MISO, MOSI, SCK). The CS pin can be connected to any GPIO pin but should be passed to the constructor.
-The second argument in the constructor is the time the library should wait for the sensor to have the data available in order to read it. It is not usually a problem
-using ATmega microcontrollers but it can be a problem using fast microcontrollers such as the ESP32. For these cases, a value of around 50 would do, but should be
-customized.
+The second (optional) argument in the constructor is the time the library should wait for the sensor to have the data available in order to read it. It is not usually a problem
+using ATmega microcontrollers in Arduino UNO but it can be a problem using fast microcontrollers such as the ESP32. For these cases, a value of around 50 would do, but should be fine tuned.
 
 The angle sensor is described in more detail [here](zoetrope.io/AS5048)

--- a/lib/AS5048A/AS5048A.cpp
+++ b/lib/AS5048A/AS5048A.cpp
@@ -17,7 +17,7 @@ static const float AS5048A_TWICE_MAX_VALUE = 8191.0 * 2.0;
 static const float AS5048A_TWO_PI  = 2.0 * 3.14159265358979323846;
 
 /**
- * Constructor
+ * Constructor usign response delay (ESP32 and similars)
  */
 AS5048A::AS5048A(uint8_t arg_cs, uint8_t arg_response_delay_millis):
 	_cs(arg_cs),
@@ -26,6 +26,15 @@ AS5048A::AS5048A(uint8_t arg_cs, uint8_t arg_response_delay_millis):
 	position(0)  {
 }
 
+/**
+ * Constructor zero response delay (Arduino UNO and similars)
+ */
+AS5048A::AS5048A(uint8_t arg_cs):
+	_cs(arg_cs),
+	response_delay_millis(0),
+	errorFlag(false),
+	position(0)  {
+}
 
 /**
  * Initialiser
@@ -52,7 +61,7 @@ void AS5048A::close(){
 }
 
 /**
- * Utility function used to calculate even parity of uint16_t
+ * Utility function used to calculate even parity of an unigned 16 bit integer
  */
 uint8_t AS5048A::spiCalcEvenParity(uint16_t value){
 	uint8_t cnt = 0;
@@ -118,7 +127,7 @@ uint16_t AS5048A::getRawRotation(){
 
 /**
  * returns the value of the state register
- * @return 16 bit uint16_t containing flags
+ * @return unsigned 16 bit integer containing flags
  */
 uint16_t AS5048A::getState(){
 	return AS5048A::read(AS5048A_DIAG_AGC);
@@ -199,7 +208,9 @@ uint16_t AS5048A::read(uint16_t registerAddress){
 	SPI.transfer16(command);
 	digitalWrite(_cs,HIGH);
 
-	delay(response_delay_millis);
+	if(response_delay_millis > 0) {
+		delay(response_delay_millis);
+	}
 
 	//Now read the response
 	digitalWrite(_cs, LOW);
@@ -232,7 +243,7 @@ uint16_t AS5048A::read(uint16_t registerAddress){
 
 /**
  * TODO: make code 16-compabile so that there is not need to play arround
- * splitting bytes. Also make sure it supports ESP32.
+ * splitting and merging bytes. Also make sure it supports ESP32.
  * Write to a register
  * Takes the 16-bit  address of the target register and the unsigned 16 bit of data
  * to be written to that register
@@ -286,7 +297,9 @@ uint16_t AS5048A::write(uint16_t registerAddress, uint16_t data) {
 	SPI.transfer(right_byte);
 	digitalWrite(_cs,HIGH);
 
-	delay(response_delay_millis);
+	if(response_delay_millis > 0) {
+		delay(response_delay_millis);
+	}
 
 	//Send a NOP to get the new data in the register
 	digitalWrite(_cs, LOW);

--- a/lib/AS5048A/AS5048A.cpp
+++ b/lib/AS5048A/AS5048A.cpp
@@ -31,6 +31,7 @@ static const uint64_t h01 = 0x0101010101010101; //the sum of 256 to the power of
  */
 AS5048A::AS5048A(uint8_t arg_cs, uint8_t arg_response_delay_millis):
 	_cs(arg_cs),
+	invert_direction(false),
 	response_delay_millis(arg_response_delay_millis),
 	errorFlag(false) {
 }
@@ -40,6 +41,17 @@ AS5048A::AS5048A(uint8_t arg_cs, uint8_t arg_response_delay_millis):
  */
 AS5048A::AS5048A(uint8_t arg_cs):
 	_cs(arg_cs),
+	invert_direction(false),
+	response_delay_millis(0),
+	errorFlag(false) {
+}
+
+/**
+ * Constructor zero response delay (Arduino UNO and similars)
+ */
+AS5048A::AS5048A(uint8_t arg_cs, bool arg_invert_direction):
+	_cs(arg_cs),
+	invert_direction(arg_invert_direction),
 	response_delay_millis(0),
 	errorFlag(false) {
 }
@@ -103,6 +115,9 @@ int32_t AS5048A::getRotation(){
 float AS5048A::getRotationInDegrees(){
 	int32_t rotation = getRotation();
 	float degrees = 360.0 * (rotation + AS5048A_MAX_VALUE) / AS5048A_TWICE_MAX_VALUE;
+	if(invert_direction){
+		degrees = - degrees;
+	}
 	return degrees;
 }
 

--- a/lib/AS5048A/AS5048A.cpp
+++ b/lib/AS5048A/AS5048A.cpp
@@ -13,8 +13,8 @@ static const uint16_t AS5048A_MAGNITUDE                     = 0x3FFE;
 static const uint16_t AS5048A_ANGLE                         = 0x3FFF;
 
 static const float AS5048A_MAX_VALUE = 8191.0;
-static const float AS5048A_TWICE_MAX_VALUE = 8191.0 * 2.0;
-static const float AS5048A_TWO_PI  = 2.0 * 3.14159265358979323846;
+static const float AS5048A_TWICE_MAX_VALUE = AS5048A_MAX_VALUE * 2.0;
+static const float AS5048A_PI  = 3.14159265358979323846;
 
 /**
  * Constructor usign response delay (ESP32 and similars)
@@ -113,7 +113,7 @@ float AS5048A::getRotationInDegrees(){
 
 float AS5048A::getRotationInRadians(){
 	int32_t rotation = getRotation();
-	float degrees = AS5048A_TWO_PI * (rotation + AS5048A_MAX_VALUE) / AS5048A_TWICE_MAX_VALUE;
+	float degrees = AS5048A_PI * (rotation + AS5048A_MAX_VALUE) / AS5048A_MAX_VALUE;
 	return degrees;
 }
 

--- a/lib/AS5048A/AS5048A.cpp
+++ b/lib/AS5048A/AS5048A.cpp
@@ -46,6 +46,7 @@ void AS5048A::init(){
 
 	//setup pins
 	pinMode(_cs, OUTPUT);
+	digitalWrite(_cs, HIGH);
 
 	//SPI has an internal SPI-device counter, it is possible to call "begin()" from different devices
 	SPI.begin();

--- a/lib/AS5048A/AS5048A.cpp
+++ b/lib/AS5048A/AS5048A.cpp
@@ -2,7 +2,7 @@
 
 #include <AS5048A.h>
 
-#define AS5048A_DEBUG
+// #define AS5048A_DEBUG
 
 static const uint16_t AS5048A_CLEAR_ERROR_FLAG              = 0x0001;
 static const uint16_t AS5048A_PROGRAMMING_CONTROL           = 0x0003;

--- a/lib/AS5048A/AS5048A.cpp
+++ b/lib/AS5048A/AS5048A.cpp
@@ -43,7 +43,6 @@ AS5048A::AS5048A(uint8_t arg_cs):
 void AS5048A::init(){
 	// 1MHz clock (AMS should be able to accept up to 10MHz)
 	settings = SPISettings(1000000, MSBFIRST, SPI_MODE1);
-	SPI.setDataMode (SPI_MODE1) ;
 
 	//setup pins
 	pinMode(_cs, OUTPUT);

--- a/lib/AS5048A/AS5048A.cpp
+++ b/lib/AS5048A/AS5048A.cpp
@@ -2,23 +2,28 @@
 
 #include <AS5048A.h>
 
-//#define AS5048A_DEBUG
+#define AS5048A_DEBUG
 
-const int AS5048A_CLEAR_ERROR_FLAG              = 0x0001;
-const int AS5048A_PROGRAMMING_CONTROL           = 0x0003;
-const int AS5048A_OTP_REGISTER_ZERO_POS_HIGH    = 0x0016;
-const int AS5048A_OTP_REGISTER_ZERO_POS_LOW     = 0x0017;
-const int AS5048A_DIAG_AGC                      = 0x3FFD;
-const int AS5048A_MAGNITUDE                     = 0x3FFE;
-const int AS5048A_ANGLE                         = 0x3FFF;
+static const uint16_t AS5048A_CLEAR_ERROR_FLAG              = 0x0001;
+static const uint16_t AS5048A_PROGRAMMING_CONTROL           = 0x0003;
+static const uint16_t AS5048A_OTP_REGISTER_ZERO_POS_HIGH    = 0x0016;
+static const uint16_t AS5048A_OTP_REGISTER_ZERO_POS_LOW     = 0x0017;
+static const uint16_t AS5048A_DIAG_AGC                      = 0x3FFD;
+static const uint16_t AS5048A_MAGNITUDE                     = 0x3FFE;
+static const uint16_t AS5048A_ANGLE                         = 0x3FFF;
+
+static const float AS5048A_MAX_VALUE = 8191.0;
+static const float AS5048A_TWICE_MAX_VALUE = 8191.0 * 2.0;
+static const float AS5048A_TWO_PI  = 2.0 * 3.14159265358979323846;
 
 /**
  * Constructor
  */
-AS5048A::AS5048A(byte arg_cs){
-	_cs = arg_cs;
-	errorFlag = false;
-	position = 0;
+AS5048A::AS5048A(uint8_t arg_cs, uint8_t arg_response_delay_millis):
+	_cs(arg_cs),
+	response_delay_millis(arg_response_delay_millis),
+	errorFlag(false),
+	position(0)  {
 }
 
 
@@ -29,7 +34,8 @@ AS5048A::AS5048A(byte arg_cs){
 void AS5048A::init(){
 	// 1MHz clock (AMS should be able to accept up to 10MHz)
 	settings = SPISettings(1000000, MSBFIRST, SPI_MODE1);
-	
+	SPI.setDataMode (SPI_MODE1) ;
+
 	//setup pins
 	pinMode(_cs, OUTPUT);
 
@@ -46,13 +52,12 @@ void AS5048A::close(){
 }
 
 /**
- * Utility function used to calculate even parity of word
+ * Utility function used to calculate even parity of uint16_t
  */
-byte AS5048A::spiCalcEvenParity(word value){
-	byte cnt = 0;
-	byte i;
+uint8_t AS5048A::spiCalcEvenParity(uint16_t value){
+	uint8_t cnt = 0;
 
-	for (i = 0; i < 16; i++)
+	for (uint8_t i = 0; i < 16; i++)
 	{
 		if (value & 0x1)
 		{
@@ -68,14 +73,12 @@ byte AS5048A::spiCalcEvenParity(word value){
 /**
  * Get the rotation of the sensor relative to the zero position.
  *
- * @return {int} between -2^13 and 2^13
+ * @return {int32_t} between -2^13 and 2^13
  */
-int AS5048A::getRotation(){
-	word data;
-	int rotation;
+int32_t AS5048A::getRotation(){
 
-	data = AS5048A::getRawRotation();
-	rotation = (int)data - (int)position;
+	uint16_t data = AS5048A::getRawRotation();
+	int32_t rotation = (int32_t)data - (int32_t)position;
 	if(rotation > 8191) rotation = -((0x3FFF)-rotation); //more than -180
 	//if(rotation < -0x1FFF) rotation = rotation+0x3FFF;
 
@@ -83,17 +86,41 @@ int AS5048A::getRotation(){
 }
 
 /**
+ * Get the rotation of the sensor relative to the zero position in degrees.
+ *
+ * @return {float} between 0 and 360
+ */
+
+float AS5048A::getRotationInDegrees(){
+	int32_t rotation = getRotation();
+	float degrees = 360.0 * (rotation + AS5048A_MAX_VALUE) / AS5048A_TWICE_MAX_VALUE;
+	return degrees;
+}
+
+/**
+ * Get the rotation of the sensor relative to the zero position in radians.
+ *
+ * @return {float} between 0 and 2 * PI
+ */
+
+float AS5048A::getRotationInRadians(){
+	int32_t rotation = getRotation();
+	float degrees = AS5048A_TWO_PI * (rotation + AS5048A_MAX_VALUE) / AS5048A_TWICE_MAX_VALUE;
+	return degrees;
+}
+
+/**
  * Returns the raw angle directly from the sensor
  */
-word AS5048A::getRawRotation(){
+uint16_t AS5048A::getRawRotation(){
 	return AS5048A::read(AS5048A_ANGLE);
 }
 
 /**
  * returns the value of the state register
- * @return 16 bit word containing flags
+ * @return 16 bit uint16_t containing flags
  */
-word AS5048A::getState(){
+uint16_t AS5048A::getState(){
 	return AS5048A::read(AS5048A_DIAG_AGC);
 }
 
@@ -101,9 +128,7 @@ word AS5048A::getState(){
  * Print the diagnostic register of the sensor
  */
 void AS5048A::printState(){
-	word data;
-
-	data = AS5048A::getState();
+	uint16_t data = AS5048A::getState();
 	if(AS5048A::error()){
 		Serial.print("Error bit was set!");
 	}
@@ -114,54 +139,50 @@ void AS5048A::printState(){
  * Returns the value used for Automatic Gain Control (Part of diagnostic
  * register)
  */
-byte AS5048A::getGain(){
-	word data = AS5048A::getState();
-	return (byte) data & 0xFF;
+uint8_t AS5048A::getGain(){
+	uint16_t data = AS5048A::getState();
+	return (uint8_t) data & 0xFF;
 }
 
 /*
  * Get and clear the error register by reading it
  */
-word AS5048A::getErrors(){
+uint16_t AS5048A::getErrors(){
 	return AS5048A::read(AS5048A_CLEAR_ERROR_FLAG);
 }
 
 /*
  * Set the zero position
  */
-void AS5048A::setZeroPosition(word arg_position){
+void AS5048A::setZeroPosition(uint16_t arg_position){
 	position = arg_position % 0x3FFF;
 }
 
-/*
+/**
  * Returns the current zero position
  */
-word AS5048A::getZeroPosition(){
+uint16_t AS5048A::getZeroPosition(){
 	return position;
 }
 
-/*
+/**
  * Check if an error has been encountered.
  */
 bool AS5048A::error(){
 	return errorFlag;
 }
 
-/*
+/**
  * Read a register from the sensor
- * Takes the address of the register as a 16 bit word
+ * Takes the address of the register as an unsigned 16 bit
  * Returns the value of the register
  */
-word AS5048A::read(word registerAddress){
-	word command = 0b0100000000000000; // PAR=0 R/W=R
+uint16_t AS5048A::read(uint16_t registerAddress){
+	uint16_t command = 0b0100000000000000; // PAR=0 R/W=R
 	command = command | registerAddress;
 
 	//Add a parity bit on the the MSB
-	command |= ((word)spiCalcEvenParity(command)<<15);
-
-	//Split the command into two bytes
-	byte right_byte = command & 0xFF;
-	byte left_byte = ( command >> 8 ) & 0xFF;
+	command |= ((uint16_t)spiCalcEvenParity(command)<<15);
 
 #ifdef AS5048A_DEBUG
 	Serial.print("Read (0x");
@@ -175,14 +196,14 @@ word AS5048A::read(word registerAddress){
 
 	//Send the command
 	digitalWrite(_cs, LOW);
-	SPI.transfer(left_byte);
-	SPI.transfer(right_byte);
+	SPI.transfer16(command);
 	digitalWrite(_cs,HIGH);
+
+	delay(response_delay_millis);
 
 	//Now read the response
 	digitalWrite(_cs, LOW);
-	left_byte = SPI.transfer(0x00);
-	right_byte = SPI.transfer(0x00);
+	uint16_t response = SPI.transfer16(0x0000);
 	digitalWrite(_cs, HIGH);
 
 	//SPI - end transaction
@@ -190,13 +211,11 @@ word AS5048A::read(word registerAddress){
 
 #ifdef AS5048A_DEBUG
 	Serial.print("Read returned: ");
-	Serial.print(left_byte, BIN);
-	Serial.print(" ");
-	Serial.println(right_byte, BIN);
+	Serial.println(response, BIN);
 #endif
 
 	//Check if the error bit is set
-	if (left_byte & 0x40) {
+	if (response & 0x4000) {
 #ifdef AS5048A_DEBUG
 		Serial.println("Setting error bit");
 #endif
@@ -207,28 +226,30 @@ word AS5048A::read(word registerAddress){
 	}
 
 	//Return the data, stripping the parity and error bits
-	return (( ( left_byte & 0xFF ) << 8 ) | ( right_byte & 0xFF )) & ~0xC000;
+	return response & ~0xC000;
 }
 
 
-/*
+/**
+ * TODO: make code 16-compabile so that there is not need to play arround
+ * splitting bytes. Also make sure it supports ESP32.
  * Write to a register
- * Takes the 16-bit  address of the target register and the 16 bit word of data
+ * Takes the 16-bit  address of the target register and the unsigned 16 bit of data
  * to be written to that register
  * Returns the value of the register after the write has been performed. This
  * is read back from the sensor to ensure a sucessful write.
  */
-word AS5048A::write(word registerAddress, word data) {
+uint16_t AS5048A::write(uint16_t registerAddress, uint16_t data) {
 
-	word command = 0b0000000000000000; // PAR=0 R/W=W
+	uint16_t command = 0b0000000000000000; // PAR=0 R/W=W
 	command |= registerAddress;
 
 	//Add a parity bit on the the MSB
-	command |= ((word)spiCalcEvenParity(command)<<15);
+	command |= ((uint16_t)spiCalcEvenParity(command)<<15);
 
 	//Split the command into two bytes
-	byte right_byte = command & 0xFF;
-	byte left_byte = ( command >> 8 ) & 0xFF;
+	uint8_t right_byte = command & 0xFF;
+	uint8_t left_byte = ( command >> 8 ) & 0xFF;
 
 #ifdef AS5048A_DEBUG
 	Serial.print("Write (0x");
@@ -245,12 +266,12 @@ word AS5048A::write(word registerAddress, word data) {
 	SPI.transfer(left_byte);
 	SPI.transfer(right_byte);
 	digitalWrite(_cs,HIGH);
-	
-	word dataToSend = 0b0000000000000000;
+
+	uint16_t dataToSend = 0b0000000000000000;
 	dataToSend |= data;
 
 	//Craft another packet including the data and parity
-	dataToSend |= ((word)spiCalcEvenParity(dataToSend)<<15);
+	dataToSend |= ((uint16_t)spiCalcEvenParity(dataToSend)<<15);
 	right_byte = dataToSend & 0xFF;
 	left_byte = ( dataToSend >> 8 ) & 0xFF;
 
@@ -264,7 +285,9 @@ word AS5048A::write(word registerAddress, word data) {
 	SPI.transfer(left_byte);
 	SPI.transfer(right_byte);
 	digitalWrite(_cs,HIGH);
-	
+
+	delay(response_delay_millis);
+
 	//Send a NOP to get the new data in the register
 	digitalWrite(_cs, LOW);
 	left_byte =-SPI.transfer(0x00);

--- a/lib/AS5048A/AS5048A.cpp
+++ b/lib/AS5048A/AS5048A.cpp
@@ -242,7 +242,7 @@ uint16_t AS5048A::read(uint16_t registerAddress){
 
 
 /**
- * TODO: make code 16-compabile so that there is not need to play arround
+ * TODO: make code 16-compabile so that there is not need to play around
  * splitting and merging bytes. Also make sure it supports ESP32.
  * Write to a register
  * Takes the 16-bit  address of the target register and the unsigned 16 bit of data

--- a/lib/AS5048A/AS5048A.h
+++ b/lib/AS5048A/AS5048A.h
@@ -11,6 +11,7 @@ class AS5048A{
 	// if the microcontroller is fast (e.g. ESP32) it should take a value around 50 so that the slave has time to send the response
 	uint8_t response_delay_millis;
 	SPISettings settings;
+	bool invert_direction;
 
 	public:
 
@@ -18,6 +19,7 @@ class AS5048A{
 	 *	Constructors
 	 */
 	AS5048A(uint8_t arg_cs);
+	AS5048A(uint8_t arg_cs, bool invert_direction);
 	AS5048A(uint8_t arg_cs, uint8_t arg_response_delay_millis);
 
 	/**

--- a/lib/AS5048A/AS5048A.h
+++ b/lib/AS5048A/AS5048A.h
@@ -10,7 +10,6 @@ class AS5048A{
 	uint8_t _cs;
 	// if the microcontroller is fast (e.g. ESP32) it should take a value around 50 so that the slave has time to send the response
 	uint8_t response_delay_millis;
-	uint16_t position;
 	SPISettings settings;
 
 	public:
@@ -84,9 +83,9 @@ class AS5048A{
 	uint16_t getErrors();
 
 	/*
-	 * Set the zero position
+	 * Set the zero position in the sensor
 	 */
-	void setZeroPosition(uint16_t arg_position);
+	bool setZeroPosition(uint16_t position);
 
 	/*
 	 * Returns the current zero position
@@ -114,6 +113,6 @@ class AS5048A{
 
 	private:
 
-	uint8_t spiCalcEvenParity(uint16_t);
+	uint16_t spiCalcEvenParity(uint16_t);
 };
 #endif

--- a/lib/AS5048A/AS5048A.h
+++ b/lib/AS5048A/AS5048A.h
@@ -1,6 +1,6 @@
 #ifndef as5048_h
 #define as5048_h
-#define LIBRARY_VERSION 1.0.1
+#define LIBRARY_VERSION 1.1.0
 
 #include <SPI.h>
 

--- a/lib/AS5048A/AS5048A.h
+++ b/lib/AS5048A/AS5048A.h
@@ -11,15 +11,14 @@ class AS5048A{
 	// if the microcontroller is fast (e.g. ESP32) it should take a value around 50 so that the slave has time to send the response
 	uint8_t response_delay_millis;
 	uint16_t position;
-	uint16_t transaction(uint16_t data);
-
 	SPISettings settings;
 
 	public:
 
 	/**
-	 *	Constructor
+	 *	Constructors
 	 */
+	AS5048A(uint8_t arg_cs);
 	AS5048A(uint8_t arg_cs, uint8_t arg_response_delay_millis);
 
 	/**

--- a/lib/AS5048A/AS5048A.h
+++ b/lib/AS5048A/AS5048A.h
@@ -7,22 +7,20 @@
 class AS5048A{
 
 	bool errorFlag;
-	byte _cs;
-	byte cs;
-	byte dout;
-	byte din;
-	byte clk;
-	word position;
-	word transaction(word data);
-	
+	uint8_t _cs;
+	// if the microcontroller is fast (e.g. ESP32) it should take a value around 50 so that the slave has time to send the response
+	uint8_t response_delay_millis;
+	uint16_t position;
+	uint16_t transaction(uint16_t data);
+
 	SPISettings settings;
-	
+
 	public:
 
 	/**
 	 *	Constructor
 	 */
-	AS5048A(byte arg_cs);
+	AS5048A(uint8_t arg_cs, uint8_t arg_response_delay_millis);
 
 	/**
 	 * Initialiser
@@ -37,38 +35,38 @@ class AS5048A{
 
 	/*
 	 * Read a register from the sensor
-	 * Takes the address of the register as a 16 bit word
+	 * Takes the address of the register as a 16 bit uint16_t
 	 * Returns the value of the register
 	 */
-	word read(word registerAddress);
+	uint16_t read(uint16_t registerAddress);
 
 	/*
 	 * Write to a register
-	 * Takes the 16-bit  address of the target register and the 16 bit word of data
+	 * Takes the 16-bit  address of the target register and the 16 bit uint16_t of data
 	 * to be written to that register
 	 * Returns the value of the register after the write has been performed. This
 	 * is read back from the sensor to ensure a sucessful write.
 	 */
-	word write(word registerAddress, word data);
+	uint16_t write(uint16_t registerAddress, uint16_t data);
 
 	/**
 	 * Get the rotation of the sensor relative to the zero position.
 	 *
 	 * @return {int} between -2^13 and 2^13
 	 */
-	int getRotation();
+	int32_t getRotation();
 
 	/**
 	 * Returns the raw angle directly from the sensor
 	 */
-	word getRawRotation();
+	uint16_t getRawRotation();
 
 
 	/**
 	 * returns the value of the state register
-	 * @return 16 bit word containing flags
+	 * @return 16 bit uint16_t containing flags
 	 */
-	word getState();
+	uint16_t getState();
 
 	/**
 	 * Print the diagnostic register of the sensor
@@ -79,22 +77,36 @@ class AS5048A{
 	 * Returns the value used for Automatic Gain Control (Part of diagnostic
 	 * register)
 	 */
-	byte getGain();
+	uint8_t getGain();
 
 	/*
 	 * Get and clear the error register by reading it
 	 */
-	word getErrors();
+	uint16_t getErrors();
 
 	/*
 	 * Set the zero position
 	 */
-	void setZeroPosition(word arg_position);
+	void setZeroPosition(uint16_t arg_position);
 
 	/*
 	 * Returns the current zero position
 	 */
-	word getZeroPosition();
+	uint16_t getZeroPosition();
+
+	/**
+	 * Get the rotation of the sensor relative to the zero position in degrees.
+	 *
+	 * @return {float} between 0 and 360
+	 */
+	float getRotationInDegrees();
+
+	/**
+	 * Get the rotation of the sensor relative to the zero position in radians.
+	 *
+	 * @return {float} between 0 and 2 * PI
+	 */
+	float getRotationInRadians();
 
 	/*
 	 * Check if an error has been encountered.
@@ -103,6 +115,6 @@ class AS5048A{
 
 	private:
 
-	byte spiCalcEvenParity(word);
+	uint8_t spiCalcEvenParity(uint16_t);
 };
 #endif

--- a/src/sketch_arduino_uno.ino
+++ b/src/sketch_arduino_uno.ino
@@ -1,7 +1,7 @@
 #include <AS5048A.h>
 
 
-AS5048A angleSensor(10, 0);
+AS5048A angleSensor(10);
 
 void setup()
 {

--- a/src/sketch_arduino_uno.ino
+++ b/src/sketch_arduino_uno.ino
@@ -1,0 +1,23 @@
+#include <AS5048A.h>
+
+
+AS5048A angleSensor(10, 0);
+
+void setup()
+{
+	Serial.begin(19200);
+	angleSensor.init();
+}
+
+void loop()
+{
+	delay(1000);
+
+	word val = angleSensor.getRawRotation();
+	Serial.print("Got rotation of: 0x");
+	Serial.println(val, HEX);
+	Serial.print("State: ");
+	angleSensor.printState();
+	Serial.print("Errors: ");
+	Serial.println(angleSensor.getErrors());
+}

--- a/src/sketch_esp32_nodemcu.ino
+++ b/src/sketch_esp32_nodemcu.ino
@@ -1,7 +1,7 @@
 #include <AS5048A.h>
 
 
-AS5048A angleSensor(10);
+AS5048A angleSensor(SS, 50);
 
 void setup()
 {


### PR DESCRIPTION
The library doesn't work using  ESP32 microcontrollers, the pull request resolves the issue. The reason is pretty simple.  For fast microcontrollers it seems when sending a transfer, it's necessary to wait for the sensor to have data to be received.

I found several other problems, such as the use of *word*  or *int* types which are not architecture-independant. I also seized the opportunity to remove a few class variables not used, and modernize the code a bit (constructor assignment, constants, variable declaration...)

Furthermore, I simplified the *write* method, removed all the code that splits and merges  16 bits variables into 8 bits. Same shall be done for *write*, which I will probably do later on.

Finally I added methods to get the rotation in degrees and radians.

Thanks for the library by the way!

... two more things:

The code is tested with Arduino UNO and ESP32. It seems to work for both.
I added sketches for both and renamed them so that they fit specifically the microcontroller type.